### PR TITLE
Better doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ see <http://unlicense.org/> or the accompanying {file:LICENSE} file.
 [RDF.rb]:       http://rubydoc.info/github/ruby-rdf/rdf-normalize
 [N-Triples]:    http://www.w3.org/TR/rdf-testcases/#ntriples
 [RDF Normalize]:http://json-ld.github.io/normalization/spec/
-[Normalize doc]:http://rubydoc.info/github/ruby-rdf/rdf-normalize/master/file/README.markdown
+[Normalize doc]:http://rubydoc.info/github/ruby-rdf/rdf-normalize/master


### PR DESCRIPTION
The old link is broken, and could be fixed by changing .markdown to .md

This is a better solution tho IMO, as it shows the doc tree as well as the readme.

